### PR TITLE
Add batch mode --verbose, --nocolor options and allow selecting/deselecting tests by regex patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.egg-info
 htmlcov
+*.pyc
+__pycache__
+

--- a/assay/command.py
+++ b/assay/command.py
@@ -10,12 +10,16 @@ from . import monitor, unix
 def main():
     os.environ['PYTHONDONTWRITEBYTECODE'] = 'please'
     sys.dont_write_bytecode = True
-    parser = argparse.ArgumentParser(prog='assay')
+    parser = argparse.ArgumentParser(prog='assay', prefix_chars='-+')
     parser.description = 'Fast testing framework'
     parser.add_argument('name', nargs='+',
         help='directory, package, or module to test')
     parser.add_argument('-b', '--batch', action='store_true',
         help='run tests once, then exit with success or failure')
+    parser.add_argument('--pattern', '-k', action='append', metavar='REGEX',
+        help='only run test functions matching the regular expression REGEX')
+    parser.add_argument('--deselect', '+k', action='append', metavar='REGEX',
+        help='do not run test functions matching the regular expression REGEX')
     parser.add_argument('-v', '--verbose', action='store_true',
         help='be verbose in batch mode: print test names being tested')
     #checked on sys.argv directly. Only to allow and include it in helptext
@@ -29,6 +33,7 @@ def main():
     try:
         with unix.configure_tty() as isatty:
             monitor.main_loop(args.name, args.batch or not isatty,
+                              patterns=[args.pattern, args.deselect],
                               verbose=args.verbose)
     except monitor.Restart:
         print()

--- a/assay/command.py
+++ b/assay/command.py
@@ -14,12 +14,22 @@ def main():
     parser.description = 'Fast testing framework'
     parser.add_argument('name', nargs='+',
         help='directory, package, or module to test')
-    parser.add_argument('--batch', action='store_true',
+    parser.add_argument('-b', '--batch', action='store_true',
         help='run tests once, then exit with success or failure')
+    parser.add_argument('-v', '--verbose', action='store_true',
+        help='be verbose in batch mode: print test names being tested')
+    #checked on sys.argv directly. Only to allow and include it in helptext
+    parser.add_argument('-c', '--nocolor', action='store_true',
+        help='suppress colored printout')
     args = parser.parse_args()
+    if args.verbose:
+        if not args.batch:
+            print('Error: --verbose only valid in batch mode')
+            sys.exit(64)
     try:
         with unix.configure_tty() as isatty:
-            monitor.main_loop(args.name, args.batch or not isatty)
+            monitor.main_loop(args.name, args.batch or not isatty,
+                              verbose=args.verbose)
     except monitor.Restart:
         print()
         print(' Restart '.center(79, '='))

--- a/assay/monitor.py
+++ b/assay/monitor.py
@@ -31,7 +31,7 @@ def write(string):
     """Send `string` immediately to standard output, without buffering."""
     os.write(stdout_fd, string.encode('ascii'))
 
-def main_loop(arguments, batch_mode):
+def main_loop(arguments, batch_mode, verbose=False):
     """Run and report on tests while also letting the user type commands."""
 
     main_process_paths = set(path for name, path in list_module_paths())
@@ -58,7 +58,7 @@ def main_loop(arguments, batch_mode):
         paths_under_test = set()
         reporter = reporter_class(write)
         runner = runner_coroutine(arguments, workers, reporter,
-                                  paths_under_test)
+                                  paths_under_test, verbose)
         next(runner)
 
         for source, flags in poller.events():
@@ -99,7 +99,7 @@ def main_loop(arguments, batch_mode):
                 paths_under_test = set()
                 reporter = reporter_class(write)
                 runner = runner_coroutine(arguments, workers, reporter,
-                                          paths_under_test)
+                                          paths_under_test, verbose)
                 next(runner)
 
             # import_order = improve_order(import_order, dangers)
@@ -110,7 +110,8 @@ def main_loop(arguments, batch_mode):
         for worker in workers:
             worker.close()
 
-def runner_coroutine(arguments, workers, reporter, paths_under_test):
+def runner_coroutine(arguments, workers, reporter, paths_under_test,
+                     verbose=False):
     worker = workers[0]
     running_workers = set()
     names = []
@@ -143,7 +144,7 @@ def runner_coroutine(arguments, workers, reporter, paths_under_test):
             if result is StopIteration:
                 give_work_to(worker)
             else:
-                reporter.report_result(result)
+                reporter.report_result(result, verbose)
 
     finally:
         for worker in workers:

--- a/assay/reporting.py
+++ b/assay/reporting.py
@@ -20,6 +20,8 @@ help_message = """
  [?] Help (this summary)
 """  # Future: [m] Pipe all errors to more(1) or else your custom $PAGER
 
+color = "--nocolor" not in sys.argv[1:] and "-c" not in sys.argv[1:]
+
 class BatchReporter(object):
     def __init__(self, write_callback):
         self.write_callback = write_callback
@@ -27,10 +29,14 @@ class BatchReporter(object):
         self.tests = 0
         self.t0 = time()
 
-    def report_result(self, result):
+    def report_result(self, result, verbose=False):
         self.tests += 1
-        if result == '.':
-            self.write_callback('.')
+        if result[0] == '.':
+            if verbose:
+                self.write_callback("{:.<72s} {}\n".format(
+                    (result[1] +'(' + result[2] + ')'), green("[ OK ]")))
+            else:
+                self.write_callback('.')
         else:
             self.errors += 1
             self.write_callback(pretty_format_error(*result))
@@ -63,8 +69,11 @@ class InteractiveReporter(object):
             s = s[i+1:]
         self.column += len(s) - s.count('\033') // 2 * 11
 
-    def report_result(self, result):
-        is_success = (result == '.')
+    def report_result(self, result, verbose=None):
+        if verbose:
+            raise NotImplementedError(
+                "no verbose flag for interactive reporter")
+        is_success = (result[0] == '.')
         letter = '.' if is_success else result[0]
         self.letters.append(letter)
         if not self.errors:
@@ -166,17 +175,18 @@ def pretty_format_error(character, name, message, frames, out='', err=''):
 
     return '\n'.join(lines)
 
+
 def black(text): # ';47' does bg color
-    return '\033[1;30m' + str(text) + '\033[0m'
+    return '\033[1;30m' + str(text) + '\033[0m' if color else str(text)
 
 def red(text):
-    return '\033[1;31m' + str(text) + '\033[0m'
+    return '\033[1;31m' + str(text) + '\033[0m' if color else str(text)
 
 def green(text):
-    return '\033[1;32m' + str(text) + '\033[0m'
+    return '\033[1;32m' + str(text) + '\033[0m' if color else str(text)
 
 def yellow(text):
-    return '\033[1;33m' + str(text) + '\033[0m'
+    return '\033[1;33m' + str(text) + '\033[0m' if color else str(text)
 
 def blue(text):
-    return '\033[1;35m' + str(text) + '\033[0m'
+    return '\033[1;35m' + str(text) + '\033[0m' if color else str(text)

--- a/assay/runner.py
+++ b/assay/runner.py
@@ -141,7 +141,7 @@ def run_test_with_arguments(test, args):
         frames = traceback_frames()
         return 'E', type(e).__name__, str(e), add_args(frames, args)
     else:
-        return '.'
+        return '.', test.__name__, ", ".join([str(a) for a in args])
 
     if (not message) and function and not hasattr(function, 'assay_rewritten'):
         rewrite_asserts_in(function)

--- a/assay/samples.py
+++ b/assay/samples.py
@@ -64,6 +64,13 @@ def fix3():
 def test_fix4(test_exc):
     pass
 
+twofix1 = [1, 2]
+twofix2 = [3, 4]
+
+def test_twofix(twofix1, twofix2):
+    assert twofix1 in [1, 2]
+    assert twofix2 in [3, 4]
+
 def test_syntax_error():
     eval('1+2!3')
 


### PR DESCRIPTION
Hi,

This PR introduces 3 new features split in two and a half commits:

1. Add the command argument `-c, --nocolor` to disable the tty color coding. Useful for CI logs, where the coloring control sequences look ugly, e.g. the openSUSE Build Service.
2. Add the command argument `-v, --verbose` (available in batch mode only) to show which tests are running and passing instead of just a '.'
3. Add the command family `--pattern REGEX, -k REGEX` and `--deselect REGEX, + REGEX` to filter tests by regular expressions.

```
$ python3 -m assay -h      
usage: assay [-h] [-b] [--pattern REGEX] [--deselect REGEX] [-v] [-c] name [name ...]

Fast testing framework

positional arguments:
  name                  directory, package, or module to test

optional arguments:
  -h, --help            show this help message and exit
  -b, --batch           run tests once, then exit with success or failure
  --pattern REGEX, -k REGEX
                        only run test functions matching the regular expression REGEX
  --deselect REGEX, +k REGEX
                        do not run test functions matching the regular expression REGEX
  -v, --verbose         be verbose in batch mode: print test names being tested
  -c, --nocolor         suppress colored printout
```