### PR TITLE
KQueue implementation (macos)

### DIFF
--- a/assay/monitor.py
+++ b/assay/monitor.py
@@ -39,7 +39,7 @@ def main_loop(arguments, batch_mode):
 
     main_process_paths = set(path for name, path in list_module_paths())
 
-    poller = unix.EPoll()
+    poller = unix.poller()
     if batch_mode:
         file_watcher = None
         reporter_class = BatchReporter


### PR DESCRIPTION
Includes one commit from @dkua that added a KQueue class, but wasn't quite functional yet. The second commit makes it functional and also adds a `poller()` function to select a queue implementation depending on platform.

I've run this on MacOS with a single test and got a dot! It only works on MacOS in --batch mode because MacOS doesn't support the inotify file watcher.

`./test.sh` is currently failing for me locally, but I believe this is unrelated to the changes (I doubt the tests ever passed on MacOS).

This stems from the discussion on #4.